### PR TITLE
Fix images not displaying properly

### DIFF
--- a/src/announcements/templates/announcements/list.html
+++ b/src/announcements/templates/announcements/list.html
@@ -10,14 +10,15 @@
 {% block content %}
 <div class="panel-group panel-group-packed" id="accordion" role="tablist" aria-multiselectable="true">
 {% for object in object_list %}
-  <div id="{{object.id}}" 
+  <div id="{{object.id}}"
     class="panel accordian anchor
     {% if object.id == active_id %} active active-anchor{% endif %}
     {% if object|notification_unread:request.user %}panel-warning note-unread
-    {% elif object.not_yet_released %}panel-warning
-    {% elif object.draft %}panel-warning
-    {% elif object.sticky %}panel-info
-    {% else %}panel-default
+      {% elif object.not_yet_released %}panel-warning
+      {% elif object.draft %}panel-warning
+      {% elif object.sticky %}panel-info
+    {% else %}
+      panel-default
     {% endif %}">
     <div
       {% if object|notification_unread:request.user %}
@@ -58,7 +59,7 @@
           </div>
           {% endif %}
           <!-- <i class="fa fa-quote-left fa-2x pull-left"></i> -->
-          <div>
+          <div class="clearfix">
             {{object.content|safe}}
           </div>
         </li>


### PR DESCRIPTION
 Fixes #266 

Before:
<img width="740" alt="Screen Shot 2020-03-29 at 10 05 38 AM" src="https://user-images.githubusercontent.com/10972027/77838301-6bc77e00-71a5-11ea-8473-0dd374bdce70.png">

After:

<img width="840" alt="Screen Shot 2020-03-29 at 10 09 22 AM" src="https://user-images.githubusercontent.com/10972027/77838303-72ee8c00-71a5-11ea-8260-329c2b8964b8.png">
