### PR TITLE
Add Basic and Advanced sections in QuestForm

### DIFF
--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -1,7 +1,7 @@
 from bootstrap_datepicker_plus import DatePickerInput, TimePickerInput
-from crispy_forms.bootstrap import Tab, TabHolder
+from crispy_forms.bootstrap import Accordion, AccordionGroup
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Layout
+from crispy_forms.layout import Layout, Div
 from django import forms
 from django_select2.forms import ModelSelect2MultipleWidget
 from django_summernote.widgets import SummernoteInplaceWidget
@@ -54,38 +54,41 @@ class QuestForm(forms.ModelForm):
         super(QuestForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.layout = Layout(
-            TabHolder(
-                Tab(
-                    'Basic',
-                    'name',
-                    'xp',
-                    'visible_to_students',
-                    'verification_required',
-                    'icon',
-                    'short_description',
-                    'instructions',
-                    'submission_details',
-                    'instructor_notes',
-                    'campaign',
-                    'common_data',
-                    'max_repeats',
-                    'hours_between_repeats',
+            Div(
+                Accordion(
+                    AccordionGroup(
+                        'Basic',
+                        'name',
+                        'xp',
+                        'visible_to_students',
+                        'verification_required',
+                        'icon',
+                        'short_description',
+                        'instructions',
+                        'submission_details',
+                        'instructor_notes',
+                        'campaign',
+                        'common_data',
+                        'max_repeats',
+                        'hours_between_repeats',
+                    ),
+                    AccordionGroup(
+                        'Advanced',
+                        'repeat_per_semester',
+                        'specific_teacher_to_notify',
+                        'blocking',
+                        'hideable',
+                        'sort_order',
+                        'date_available',
+                        'time_available',
+                        'date_expired',
+                        'time_expired',
+                        'available_outside_course',
+                        'archived',
+                        'editor',
+                    )
                 ),
-                Tab(
-                    'Advanced',
-                    'repeat_per_semester',
-                    'specific_teacher_to_notify',
-                    'blocking',
-                    'hideable',
-                    'sort_order',
-                    'date_available',
-                    'time_available',
-                    'date_expired',
-                    'time_expired',
-                    'available_outside_course',
-                    'archived',
-                    'editor',
-                ),
+                style="margin-top: 10px;"
             )
         )
 

--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -55,23 +55,20 @@ class QuestForm(forms.ModelForm):
         self.helper = FormHelper()
         self.helper.layout = Layout(
             Div(
+                'name',
+                'xp',
+                'visible_to_students',
+                'verification_required',
+                'icon',
+                'short_description',
+                'instructions',
+                'submission_details',
+                'instructor_notes',
+                'campaign',
+                'common_data',
+                'max_repeats',
+                'hours_between_repeats',
                 Accordion(
-                    AccordionGroup(
-                        'Basic',
-                        'name',
-                        'xp',
-                        'visible_to_students',
-                        'verification_required',
-                        'icon',
-                        'short_description',
-                        'instructions',
-                        'submission_details',
-                        'instructor_notes',
-                        'campaign',
-                        'common_data',
-                        'max_repeats',
-                        'hours_between_repeats',
-                    ),
                     AccordionGroup(
                         'Advanced',
                         'repeat_per_semester',
@@ -86,7 +83,8 @@ class QuestForm(forms.ModelForm):
                         'available_outside_course',
                         'archived',
                         'editor',
-                    )
+                        active=False
+                    ),
                 ),
                 style="margin-top: 10px;"
             )

--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -1,10 +1,14 @@
 from bootstrap_datepicker_plus import DatePickerInput, TimePickerInput
+from crispy_forms.bootstrap import Tab, TabHolder
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout
 from django import forms
 from django_select2.forms import ModelSelect2MultipleWidget
 from django_summernote.widgets import SummernoteInplaceWidget
 
 from badges.models import Badge
 from utilities.fields import RestrictedFileFormField
+
 from .models import Quest
 
 
@@ -48,6 +52,42 @@ class QuestForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user', None)
         super(QuestForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            TabHolder(
+                Tab(
+                    'Basic',
+                    'name',
+                    'xp',
+                    'visible_to_students',
+                    'verification_required',
+                    'icon',
+                    'short_description',
+                    'instructions',
+                    'submission_details',
+                    'instructor_notes',
+                    'campaign',
+                    'common_data',
+                    'max_repeats',
+                    'hours_between_repeats',
+                ),
+                Tab(
+                    'Advanced',
+                    'repeat_per_semester',
+                    'specific_teacher_to_notify',
+                    'blocking',
+                    'hideable',
+                    'sort_order',
+                    'date_available',
+                    'time_available',
+                    'date_expired',
+                    'time_expired',
+                    'available_outside_course',
+                    'archived',
+                    'editor',
+                ),
+            )
+        )
 
         # Don't let TA's make quests visible to students.  Teachers can do this when they approve a TA's draft quest
         if user.profile.is_TA:

--- a/src/quest_manager/templates/quest_manager/quest_form.html
+++ b/src/quest_manager/templates/quest_manager/quest_form.html
@@ -16,7 +16,7 @@
   <a href="/admin/quest_manager/quest/{{object.id}}"
      title="This is required to edit prerequisites"
      role="button" class="btn btn-default">via Admin</a>
-  {{ form|crispy }}
+  {% crispy form %}
   <a href="{% url 'quests:quests' %}" role="button" class="btn btn-danger">Cancel</a>
   <input type="submit" value="{{ submit_btn_value }}" class="btn btn-success" />
 </form>


### PR DESCRIPTION
Couldn't find other alternatives for separating sections in the
django-crispy-forms documentation. Tabs were the closest thing I could
find.

Still needs some fixes in styling

<img width="891" alt="Screen Shot 2020-03-31 at 9 47 34 PM" src="https://user-images.githubusercontent.com/10972027/78034299-1f915f00-739a-11ea-91eb-d7fa38b9dada.png">

<img width="886" alt="Screen Shot 2020-03-31 at 9 47 09 PM" src="https://user-images.githubusercontent.com/10972027/78034307-215b2280-739a-11ea-9cb9-14e63d606eb5.png">

What do you think @tylerecouture ?

Closes #326 