### PR TITLE
Fix sort order in profile list

### DIFF
--- a/src/profile_manager/templates/profile_manager/profile_list.html
+++ b/src/profile_manager/templates/profile_manager/profile_list.html
@@ -123,7 +123,7 @@
                             {{ last_submission.time_completed|date:'y/m/d' }}<br>
                             <small>{{ last_submission.time_completed|timesince }} ago</small>
                         {% else %}
-                            Never
+                            &nbsp;Never
                         {% endif %}
                       {% endwith %}
                     </td>


### PR DESCRIPTION
* Use &nbsp; to prevent `Never` from being first in the order

Closes #329 