### PR TITLE
Use site config for favicon

### DIFF
--- a/src/templates/head_css.html
+++ b/src/templates/head_css.html
@@ -51,7 +51,7 @@
 <link rel="manifest" href="{% static 'icon/manifest.json' %}">
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="msapplication-TileImage" content="{% static 'icon/ms-icon-144x144.png' %}">
-<meta name="theme-color" content="#ffffff"> 
+<meta name="theme-color" content="#ffffff">
 {% endif %}
 
-<link rel="icon" href="{% favicon_url %}">
+<link rel="icon" href="{{ config.get_favicon_url }}">


### PR DESCRIPTION
Closes #250 

Tested and working on my local

<img width="429" alt="Screen Shot 2020-04-13 at 9 08 43 PM" src="https://user-images.githubusercontent.com/10972027/79122852-5ff5d180-7dcb-11ea-9133-1c2ceedae935.png">
