### PR TITLE
Redirect to admin page without tenant

### DIFF
--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -1,23 +1,28 @@
 import functools
 
-from django.http import Http404
 from django.db import connection
-
+from django.http import Http404
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.utils.decorators import method_decorator
 from tenant_schemas.utils import get_public_schema_name
 
 
 def allow_non_public_view(f):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
+        request = args[0]
         if connection.schema_name != get_public_schema_name():
             return f(*args, **kwargs)
-        raise Http404("Page not found!")
+        elif request.path == '/':
+            return redirect(reverse('admin:index'))
 
+        raise Http404("Page not found!")
     return wrapper
 
 
 class AllowNonPublicViewMixin:
+
+    @method_decorator(allow_non_public_view)
     def dispatch(self, *args, **kwargs):
-        if connection.schema_name != get_public_schema_name():
-            return super().dispatch(*args, **kwargs)
-        raise Http404("Page not found!")
+        return super().dispatch(*args, **kwargs)


### PR DESCRIPTION
Redirect to admin page when accessing a home page without tenant

Closes #456 