### PR TITLE
Remove recalculate xp for all users link in navbar

### DIFF
--- a/src/templates/navbar-fixed.html
+++ b/src/templates/navbar-fixed.html
@@ -141,9 +141,6 @@
                     <ul class="dropdown-menu">
                         <!-- <li class="dropdown-header">Content</li> -->
                         <li><a href="{% url 'quests:flagged' %}">Flagged Submissions</a></li>
-                        <li><a title="This may take a few moments..."
-                                href="{% url 'profiles:recalculate_xp_current' %}">
-                          Recalculate XP for all current users</a></li>
                         <li><a href="/config/{{ config.id }}">Site Configuration</a></li>
                         <li role="separator" class="divider"></li>
                         <li class="dropdown-header">Database</li>


### PR DESCRIPTION
Closes #467 

`actions` already added

https://github.com/timberline-secondary/hackerspace/blob/810581a6f1e8e0e556b58d05cd84f4a3d9673eb4/src/prerequisites/admin.py#L61