### PR TITLE
Use docker-compose run instead of exec

### DIFF
--- a/init_public_schema.sh
+++ b/init_public_schema.sh
@@ -1,16 +1,16 @@
 echo -e "\n####################################"
 echo "# CREATING PUBLIC SCHEMA..."
 echo "####################################"
-docker-compose exec web python src/manage.py loaddata src/tenant/fixtures/tenants.json
+docker-compose run --rm web python src/manage.py loaddata src/tenant/fixtures/tenants.json
 
 
 echo -e "\n####################################"
 echo "# POPULATING SUPER USER..."
 echo "####################################"
-docker-compose exec web python src/manage.py loaddata src/tenant/fixtures/users.json
+docker-compose run --rm web python src/manage.py loaddata src/tenant/fixtures/users.json
 
 
 echo -e "\n####################################"
 echo "# POPULATING SITES MODEL..."
 echo "####################################"
-docker-compose exec web python src/manage.py loaddata src/initial_data.json
+docker-compose run --rm web python src/manage.py loaddata src/initial_data.json


### PR DESCRIPTION
When following the documentation under Running Code > Initial Setup
Number 6, running bash init_public_schema.sh gives an error:

```
ERROR: No container found for web_1
```

It seems that exec command requires the `web_1` to be run before we can
use it.